### PR TITLE
fix multibar.create example

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ const <instance> = new cliProgress.MultiBar(options:object [, preset:object]);
 Adds a new progress bar to the container and starts the bar. Returns regular `SingleBar` object which can be individually controlled.
 
 ```js
-const <barInstance> = <instance>.start(totalValue:int, startValue:int [, payload:object = {}]);
+const <barInstance> = <instance>.create(totalValue:int, startValue:int [, payload:object = {}]);
 ```
 
 ### ::remove() ###


### PR DESCRIPTION
The multibar `create` example code currently uses the singlebar method `start`. This PR changes it to `create`